### PR TITLE
Add Fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 Repo used to demonstrate the project https://failsafe-go.dev/
+
+
+## Examples
+
+- [x] [Timeout](https://github.com/eminetto/post-failsafe-go/pull/1)
+- [x] [Retry](https://github.com/eminetto/post-failsafe-go/pull/2)
+- [x] [Circuit Breaker](https://github.com/eminetto/post-failsafe-go/pull/3)
+- [ ] Fallback
+- [ ] Bulkhead
+- [ ] Rate Limiter
+- [ ] Policy Composition

--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
 Repo used to demonstrate the project https://failsafe-go.dev/
 
 
-## Examples
-
-- [x] [Timeout](https://github.com/eminetto/post-failsafe-go/pull/1)
-- [x] [Retry](https://github.com/eminetto/post-failsafe-go/pull/2)
-- [x] [Circuit Breaker](https://github.com/eminetto/post-failsafe-go/pull/3)
-- [ ] Fallback
-- [ ] Bulkhead
-- [ ] Rate Limiter
-- [ ] Policy Composition

--- a/serviceA/go.mod
+++ b/serviceA/go.mod
@@ -2,4 +2,7 @@ module github.com/eminetto/post-failsafe-go/sericeA
 
 go 1.22.5
 
-require github.com/go-chi/chi/v5 v5.1.0 // indirect
+require (
+	github.com/failsafe-go/failsafe-go v0.6.7 // indirect
+	github.com/go-chi/chi/v5 v5.1.0 // indirect
+)

--- a/serviceA/go.mod
+++ b/serviceA/go.mod
@@ -3,6 +3,7 @@ module github.com/eminetto/post-failsafe-go/sericeA
 go 1.22.5
 
 require (
+	github.com/bits-and-blooms/bitset v1.13.0 // indirect
 	github.com/failsafe-go/failsafe-go v0.6.7 // indirect
 	github.com/go-chi/chi/v5 v5.1.0 // indirect
 )

--- a/serviceA/go.sum
+++ b/serviceA/go.sum
@@ -1,2 +1,4 @@
+github.com/failsafe-go/failsafe-go v0.6.7 h1:blfYom5oXiaKWpZIYle38RxApE0D7z5CGjVaj6jfjio=
+github.com/failsafe-go/failsafe-go v0.6.7/go.mod h1:+/DEPYHFm4DqjP59Vgl7Ec2RJ9PoH3FnriWPquwTLc0=
 github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
 github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/serviceA/go.sum
+++ b/serviceA/go.sum
@@ -1,3 +1,5 @@
+github.com/bits-and-blooms/bitset v1.13.0 h1:bAQ9OPNFYbGHV6Nez0tmNI0RiEu7/hxlYJRUA0wFAVE=
+github.com/bits-and-blooms/bitset v1.13.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/failsafe-go/failsafe-go v0.6.7 h1:blfYom5oXiaKWpZIYle38RxApE0D7z5CGjVaj6jfjio=
 github.com/failsafe-go/failsafe-go v0.6.7/go.mod h1:+/DEPYHFm4DqjP59Vgl7Ec2RJ9PoH3FnriWPquwTLc0=
 github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=

--- a/serviceA/main.go
+++ b/serviceA/main.go
@@ -7,9 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/failsafe-go/failsafe-go"
+	"github.com/failsafe-go/failsafe-go/circuitbreaker"
 	"github.com/failsafe-go/failsafe-go/failsafehttp"
-	"github.com/failsafe-go/failsafe-go/retrypolicy"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 )
@@ -21,21 +20,35 @@ func main() {
 		type response struct {
 			Message string `json:"message"`
 		}
-		// Create a RetryPolicy that only handles 500 responses, with backoff delays between retries
-		retryPolicy := retrypolicy.Builder[*http.Response]().
-			HandleIf(func(response *http.Response, _ error) bool {
-				return response != nil && response.StatusCode == 500
+		// Create a CircuitBreaker that handles 503 responses and uses a half-open delay based on the Retry-After header
+		circuitBreaker := circuitbreaker.Builder[*http.Response]().
+			HandleIf(func(response *http.Response, err error) bool {
+				return response != nil && response.StatusCode == http.StatusServiceUnavailable
 			}).
-			WithBackoff(time.Second, 10*time.Second).
-			OnRetryScheduled(func(e failsafe.ExecutionScheduledEvent[*http.Response]) {
-				fmt.Println("Retry", e.Attempts(), "after delay of", e.Delay)
-			}).Build()
+			WithDelayFunc(failsafehttp.DelayFunc).
+			OnStateChanged(func(event circuitbreaker.StateChangedEvent) {
+				fmt.Println("circuit breaker state changed", event)
+			}).
+			Build()
 
 		// Use the RetryPolicy with a failsafe RoundTripper
-		roundTripper := failsafehttp.NewRoundTripper(nil, retryPolicy)
+		roundTripper := failsafehttp.NewRoundTripper(nil, circuitBreaker)
 		client := &http.Client{Transport: roundTripper}
 
-		resp, err := client.Get("http://localhost:3001")
+		sendGet := func() (*http.Response, error) {
+			fmt.Println("Sending request")
+			resp, err := client.Get("http://localhost:3001")
+			return resp, err
+		}
+		maxRetries := 3
+		resp, err := sendGet()
+		for i := 0; i < maxRetries; i++ {
+			if err == nil && resp != nil && resp.StatusCode != http.StatusServiceUnavailable && resp.StatusCode != http.StatusTooManyRequests {
+				break
+			}
+			time.Sleep(circuitBreaker.RemainingDelay()) // Wait for circuit breaker's delay, provided by the Retry-After header
+			resp, err = sendGet()
+		}
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))

--- a/serviceA/main.go
+++ b/serviceA/main.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"time"
 
+	"github.com/failsafe-go/failsafe-go/failsafehttp"
+	"github.com/failsafe-go/failsafe-go/timeout"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 )
@@ -16,7 +19,13 @@ func main() {
 		type response struct {
 			Message string `json:"message"`
 		}
-		resp, err := http.Get("http://localhost:3001")
+		// Create a Timeout for 1 second
+		timeOut := timeout.With[*http.Response](1 * time.Second)
+
+		// Use the Timeout with a failsafe RoundTripper
+		roundTripper := failsafehttp.NewRoundTripper(nil, timeOut)
+		client := &http.Client{Transport: roundTripper}
+		resp, err := client.Get("http://localhost:3001")
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))

--- a/serviceB/main.go
+++ b/serviceB/main.go
@@ -17,8 +17,11 @@ func main() {
 		retryAfterDelay := 1 * time.Second
 		if fail() {
 			w.Header().Add("Retry-After", strconv.Itoa(int(retryAfterDelay.Seconds())))
-			w.WriteHeader(http.StatusInternalServerError)
+			w.WriteHeader(http.StatusServiceUnavailable)
 			return
+		}
+		if sleep() {
+			time.Sleep(1 * time.Second)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"message": "hello from service B"}`))
@@ -27,6 +30,13 @@ func main() {
 }
 
 func fail() bool {
+	if flipint := rand.Intn(2); flipint == 0 {
+		return true
+	}
+	return false
+}
+
+func sleep() bool {
 	if flipint := rand.Intn(2); flipint == 0 {
 		return true
 	}

--- a/serviceB/main.go
+++ b/serviceB/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"math/rand"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -12,9 +14,21 @@ func main() {
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(5 * time.Second)
+		retryAfterDelay := 1 * time.Second
+		if fail() {
+			w.Header().Add("Retry-After", strconv.Itoa(int(retryAfterDelay.Seconds())))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"message": "hello from service B"}`))
 	})
 	http.ListenAndServe(":3001", r)
+}
+
+func fail() bool {
+	if flipint := rand.Intn(2); flipint == 0 {
+		return true
+	}
+	return false
 }

--- a/serviceB/main.go
+++ b/serviceB/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -11,6 +12,7 @@ func main() {
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second)
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"message": "hello from service B"}`))
 	})


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the `serviceA` and `serviceB` modules. The most important changes include  updating dependencies in `serviceA`, integrating fallback mechanisms in `serviceA`, and introducing retry and delay mechanisms in `serviceB`.

### Dependency Updates:

* [`serviceA/go.mod`](diffhunk://#diff-58b9ea2ef11335953263340dccc9a184e5af66cb20630fc12e20babb32e446fdL5-R9): Added new dependencies including `bitset`, `failsafe-go`, and updated the `go-chi/chi` package.

### Feature Enhancements in `serviceA`:

* [`serviceA/main.go`](diffhunk://#diff-33f78ed32082f58ae1eadc3e730b758d4a67f98d4930d3514b09c6d73b568646R4-R12): Integrated `failsafe-go` library for fallback handling, including creating a fallback response and modifying the HTTP client to use a custom round tripper. [[1]](diffhunk://#diff-33f78ed32082f58ae1eadc3e730b758d4a67f98d4930d3514b09c6d73b568646R4-R12) [[2]](diffhunk://#diff-33f78ed32082f58ae1eadc3e730b758d4a67f98d4930d3514b09c6d73b568646L16-R38) [[3]](diffhunk://#diff-33f78ed32082f58ae1eadc3e730b758d4a67f98d4930d3514b09c6d73b568646R51-R53)

### Feature Enhancements in `serviceB`:

* [`serviceB/main.go`](diffhunk://#diff-b489bd964823affd1304933f186e34a9425d2d26aa50a44dc0d4e4562323fb74R4-R7): Added logic to simulate retry and delay mechanisms by introducing `fail` and `sleep` functions, which randomly trigger service unavailability and delay responses. [[1]](diffhunk://#diff-b489bd964823affd1304933f186e34a9425d2d26aa50a44dc0d4e4562323fb74R4-R7) [[2]](diffhunk://#diff-b489bd964823affd1304933f186e34a9425d2d26aa50a44dc0d4e4562323fb74R17-R44)

## Output

```
❯ curl http://localhost:3000
{"messageA": "hello from service A","messageB": "hello from service B"}⏎

❯ curl http://localhost:3000
{"messageA": "hello from service A","messageB": "hello from service B"}⏎

❯ curl http://localhost:3000
{"messageA": "hello from service A","messageB": "hello from service B"}⏎

❯ curl http://localhost:3000
{"messageA": "hello from service A","messageB": "error accessing service B"}⏎

```
```
❯ go run main.go
{"time":"2024-08-20T08:55:27.326475-03:00","level":"INFO","msg":"200: OK","request":{"time":"2024-08-20T08:55:27.31306-03:00","method":"GET","host":"localhost:3000","path":"/","query":"","params":{},"route":"/","ip":"[::1]:63772","referer":"","length":0},"response":{"time":"2024-08-20T08:55:27.326402-03:00","latency":13343208,"status":200,"length":71},"id":""}
{"time":"2024-08-20T08:55:31.756765-03:00","level":"INFO","msg":"200: OK","request":{"time":"2024-08-20T08:55:31.754348-03:00","method":"GET","host":"localhost:3000","path":"/","query":"","params":{},"route":"/","ip":"[::1]:63774","referer":"","length":0},"response":{"time":"2024-08-20T08:55:31.756753-03:00","latency":2404750,"status":200,"length":71},"id":""}
{"time":"2024-08-20T08:55:34.091845-03:00","level":"INFO","msg":"200: OK","request":{"time":"2024-08-20T08:55:33.086273-03:00","method":"GET","host":"localhost:3000","path":"/","query":"","params":{},"route":"/","ip":"[::1]:63775","referer":"","length":0},"response":{"time":"2024-08-20T08:55:34.091812-03:00","latency":1005580625,"status":200,"length":71},"id":""}
{"time":"2024-08-20T08:55:37.386512-03:00","level":"INFO","msg":"Fallback executed result"}
{"time":"2024-08-20T08:55:37.386553-03:00","level":"INFO","msg":"200: OK","request":{"time":"2024-08-20T08:55:37.38415-03:00","method":"GET","host":"localhost:3000","path":"/","query":"","params":{},"route":"/","ip":"[::1]:63777","referer":"","length":0},"response":{"time":"2024-08-20T08:55:37.386544-03:00","latency":2393916,"status":200,"length":76},"id":""}
```